### PR TITLE
Improve Audio Errands packaging hooks and voice loading

### DIFF
--- a/docs/apps/audio-errands/index.html
+++ b/docs/apps/audio-errands/index.html
@@ -11,9 +11,9 @@
   <meta name="theme" content="bold dense" />
 
   <!-- Shared assets (single, correct paths) -->
-<link rel="stylesheet" href="/micro-apps-repository/shared/theme.css">
-<script defer src="/micro-apps-repository/shared/frame.js"></script>
-<script defer src="/micro-apps-repository/shared/clinician_feedback.js"></script>
+  <link rel="stylesheet" href="../shared/theme.css" />
+  <script defer src="../shared/frame.js"></script>
+  <script defer src="../shared/clinician_feedback.js"></script>
   <!-- App-specific styles (scoped to #app-root to avoid conflicts) -->
   <style>
     #app-root .grid{ display:grid; grid-template-columns: 1fr 320px; gap:16px; }
@@ -55,7 +55,7 @@
   </style>
 </head>
 <body>
-  <div id="app-root">
+  <main id="app-root">
     <!-- Frame.js will inject the hero header above this container -->
 
     <!-- Status row -->
@@ -150,7 +150,7 @@
       <div id="count" class="count">3</div>
       <span id="overlaySr" class="sr-only">Trial starts soon</span>
     </div>
-  </div>
+  </main>
 
   <!-- App logic (unchanged except CSV augmentation line) -->
   <script>
@@ -195,8 +195,15 @@
       });
     }
     if(synth){
-      populateVoices(); updateSpeechStatus();
-      window.speechSynthesis.onvoiceschanged = ()=>{populateVoices(); updateSpeechStatus();};
+      function refreshVoices(attempt=0){
+        populateVoices();
+        updateSpeechStatus();
+        if(!synth.getVoices().length && attempt < 8){
+          setTimeout(()=>refreshVoices(attempt+1), 200);
+        }
+      }
+      window.speechSynthesis.onvoiceschanged = ()=>{ refreshVoices(); };
+      refreshVoices();
     } else { updateSpeechStatus(); }
 
     function speak(text, {queue=false}={}){


### PR DESCRIPTION
## Summary
- swap Audio Errands shared asset imports to the repository-relative shared/ paths and wrap the UI in `<main id="app-root">` for the packager
- add a timed refresh helper for speech synthesis voices so the selector populates even when onvoiceschanged never fires

## Testing
- not run (static changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d2eba67f7c83298e978eb0dab07c76