### PR TITLE
Fix emergency service choice detection in emergency-call-simulator

### DIFF
--- a/docs/apps/emergency-call-simulator/index.html
+++ b/docs/apps/emergency-call-simulator/index.html
@@ -761,10 +761,12 @@
       }
     };
 
-    const matchesAmbulance = (input) => {
-      if (!input) return false;
+    const detectRequestedService = (input) => {
+      if (!input) return null;
       const lowered = input.toLowerCase();
-      if (lowered.includes('ambulance')) return true;
+      if (lowered.includes('ambulance')) return 'ambulance';
+      if (lowered.includes('police')) return 'police';
+      if (lowered.includes('fire')) return 'fire';
 
       const tokens = lowered
         .normalize('NFKD')
@@ -772,7 +774,11 @@
         .split(/\s+/)
         .filter(Boolean);
 
-      return tokens.some((token) => token.startsWith('ambulanc'));
+      if (tokens.some((token) => token.startsWith('ambulanc'))) return 'ambulance';
+      if (tokens.some((token) => token.startsWith('polic'))) return 'police';
+      if (tokens.some((token) => token.startsWith('fir'))) return 'fire';
+
+      return null;
     };
 
     const handleSpeechResult = (text, detail) => {
@@ -785,10 +791,10 @@
         .replace(/[^a-z\s]/g, ' ')
         .replace(/\s+/g, ' ')
         .trim();
-      const containsAmbulance = matchesAmbulance(sanitized) || matchesAmbulance(transcript);
+      const selectedService = detectRequestedService(sanitized) || detectRequestedService(transcript);
       const confidence = detail && typeof detail.confidence === 'number' ? detail.confidence : null;
 
-      if (!containsAmbulance) {
+      if (!selectedService) {
         addEvent('speech_rejected_no_match', { transcript, sanitized, confidence });
         return;
       }
@@ -798,7 +804,13 @@
         return;
       }
 
-      addEvent('speech_detected', { transcript, sanitized, confidence });
+      if (selectedService !== 'ambulance') {
+        addEvent('task_complete', { method: 'speech', selectedService, success: false });
+        finalizeFailure(`Incorrect service selected (${selectedService})`);
+        return;
+      }
+
+      addEvent('speech_detected', { transcript, sanitized, confidence, selectedService });
       recognitionSuccess = true;
       addEvent('task_complete', { method: 'speech' });
       finalizeSuccess();
@@ -1019,11 +1031,15 @@
     if (fallbackSubmit) {
       fallbackSubmit.addEventListener('click', () => {
         const value = (fallbackInput.value || '').trim().toLowerCase();
-        addEvent('fallback_submitted', { value });
-        if (value === 'ambulance') {
+        const selectedService = detectRequestedService(value);
+        addEvent('fallback_submitted', { value, selectedService });
+        if (selectedService === 'ambulance') {
           recognitionSuccess = true;
           addEvent('task_complete', { method: 'fallback_input' });
           finalizeSuccess();
+        } else if (selectedService) {
+          addEvent('task_complete', { method: 'fallback_input', selectedService, success: false });
+          finalizeFailure(`Incorrect service selected (${selectedService})`);
         } else {
           showPromptBanner('Please enter the word "Ambulance" to continue.');
         }


### PR DESCRIPTION
### Motivation
- The dialer flow should present three verbal options when 999 is dialled and mark the task successful only if the subject requests an ambulance. 
- The app previously only matched “ambulance” (or ignored other spoken options), which caused incorrect handling of police/fire responses and made the flow appear broken.

### Description
- Add a `detectRequestedService` parser that recognizes `ambulance`, `police`, and `fire` with simple, typo-tolerant token matching and returns the detected service or `null`.
- Update speech result handling to use `detectRequestedService` and treat non-ambulance selections as an explicit incorrect choice that triggers `finalizeFailure` and logs the selected service.
- Update the manual fallback submission to use the same detection function and produce consistent success/failure outcomes for typed responses.
- Small API/behavior change: the service detector returns `null` for no match (replacing previous `false` usage) and event payloads now include `selectedService` when available.

### Testing
- Started a local static server with `python3 -m http.server 4173 --directory docs`, which served the app (the server log showed 404s for `/apps/shared/*` assets due to local pathing but the JS logic changes were loadable). (succeeded with asset 404 warnings)
- Ran an automated Playwright script that opened `http://127.0.0.1:4173/apps/emergency-call-simulator/index.html`, opened the dialer, entered `999`, and captured a screenshot to `artifacts/emergency-call-simulator.png`. (succeeded)
- Generated the commit for the change file `docs/apps/emergency-call-simulator/index.html` after testing. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a05b9708a08329aa60dc610c1055a6)